### PR TITLE
Redirect to 3D scanner homepage before restart

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -40,12 +40,14 @@ router.route('/')
 // request a reboot
 router.route('/request_reboot')
     .get(function (req, res, next) {
+        res.redirect('/');
         reboot();
     })
 
 // request a shutdown
 router.route('/request_shutdown')
     .get(function (req, res, next) {
+        res.redirect('/');
         shutdown();
     })
 


### PR DESCRIPTION
Proposed change for issue #29 Redirect to 3D scanner homepage before restart/shutdown. Will redirect user to the homepage before shutting down/restarting. I have tested this and it works for me.


Summary of changes:
Added
`res.redirect('/');`
to Request a Reboot and Request a Shutdown functions.