### PR TITLE
[Feature] Added file formats

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -1,0 +1,263 @@
+/**
+ * Storage: 
+ * Contains classes and methods useful for interacting with scan files
+ * (downloading, deleting, converting etc.)
+ */
+var exports = module.exports = {};
+
+/****************************************************************************************
+* Module Includes:
+****************************************************************************************/
+const path = require('path');
+const fs = require('fs');
+const csv_parse = require('csv-parse/lib/sync');
+const replaceExt = require('replace-ext');
+
+
+
+/****************************************************************************************
+* ScanFileManager (Class):
+****************************************************************************************/
+exports.ScanFileManager = function (rootScanFileDirectory) {
+    // the main scan file directory
+    this.rootDir = rootScanFileDirectory;
+    _self = this;
+    // create the main scan file directory if it doesn't yet exist
+    if (!fs.existsSync(this.rootDir)) {
+        fs.mkdirSync(this.rootDir);
+    }
+
+    // deletes the specified file
+    this.deleteFile = function (filename) {
+        let filePath = path.join(this.rootDir, filename);
+        exports.deleteFile(filePath);
+    };
+
+    // returns a list of available scan files
+    this.getScanFiles = function () {
+        // retrieve scan files
+        let fileNames = fs.readdirSync(this.rootDir);
+        // only use CSV files
+        fileNames.filter(function (file) { return file.substr(-4) === '.csv'; });
+        // sort chronologically
+        fileNames.sort(this._compareFileTimestampDescending);
+        return fileNames;
+    };
+
+    // returns a filepath to the appropriate format file, generating the new format if necessary
+    this.getFormattedFile = function (filename, format) {
+        let csvPath = path.join(this.rootDir, filename);
+        let filePath = null;
+        switch (format) {
+            case 'csv':
+                filePath = csvPath;
+                break;
+            case 'ply':
+                filePath = _generatePLYFile(csvPath, false);
+                break;
+            case 'ply_binary':
+                filePath = _generatePLYFile(csvPath, true);
+                break;
+            case 'xyz':
+                filePath = _generateXYZFile(csvPath);
+                break;
+            default:
+                break;
+        }
+        return filePath;
+    };
+
+    this.deleteMostRecentFile = function () {
+        // retrieve chronologically sorted scan files
+        let fileNames = this.getScanFiles();
+        if (fileNames.length <= 0)
+            return;
+        // delete the most recent file
+        this.deleteFile(fileNames[0]);
+    };
+
+    // compare function used to sort a list of filenames in descending chronological order 
+    // (ie: most recent first)
+    this._compareFileTimestampDescending = function (file_a, file_b) {
+        let path_a = path.join(_self.rootDir, file_a);
+        let path_b = path.join(_self.rootDir, file_b);
+        return fs.statSync(path_b).mtime.getTime() -
+            fs.statSync(path_a).mtime.getTime();
+    };
+};
+
+/****************************************************************************************
+* Public Methods
+****************************************************************************************/
+// return true if file exists
+exports.checkFileExists = function (filePath) {
+    if (typeof filePath === 'undefined' || !filePath)
+        return false;
+    return fs.existsSync(filePath);
+};
+
+// delete file if it exists
+exports.deleteFile = function (filePath) {
+    if (fs.existsSync(filePath))
+        fs.unlinkSync(filePath);
+};
+
+
+/****************************************************************************************
+* Private Methods
+****************************************************************************************/
+
+
+
+// generate XYZ file from the specified CSV filepath
+// return the filepath if successfull, null otherwise
+let _generateXYZFile = function (csvPath) {
+    let records = _getRecords(csvPath);
+
+    if (typeof records === 'undefined' || typeof records[0] === 'undefined')
+        return null;
+
+    let buffer = _convertRecordsToXYZBuffer(records);
+
+    if (!buffer)
+        return null;
+
+    let xyzPath = replaceExt(csvPath, '.xyz');
+    fs.writeFileSync(xyzPath, buffer);
+    return xyzPath;
+}
+
+// generate PLY file from the specified CSV filepath
+// return the filepath if successfull, null otherwise
+let _generatePLYFile = function (csvPath, bCompressToBinary) {
+    let records = _getRecords(csvPath);
+
+    if (typeof records === 'undefined' || typeof records[0] === 'undefined')
+        return null;
+
+    let buffer = _convertRecordsToPLYBuffer(records, bCompressToBinary);
+
+    if (!buffer)
+        return null;
+
+    let plyPath = replaceExt(csvPath, '.ply');
+    fs.writeFileSync(plyPath, buffer);
+    return plyPath;
+}
+
+let _getRecords = function (csvPath) {
+    let data = null;
+    try {
+        data = fs.readFileSync(csvPath);
+    }
+    catch (err) {
+        console.log(`Failed to read file ${csvPath}. Error: ${err.message}`);
+        return null;
+    }
+
+    // parse the records from the csv
+    let records = null;
+
+    // csv parse options
+    let options = { columns: true, skip_empty_lines: true, trim: true, auto_parse: true };
+    try {
+        records = csv_parse(data, options);
+    }
+    catch (err) {
+        console.log(`Failed to parse CSV file. Error: ${err.message}`);
+        return null;
+    }
+    return records;
+}
+
+// converts a set of csv records to a buffer of xyz data (cartesian point cloud)
+let _convertRecordsToXYZBuffer = function (records) {
+    let numDataPoints = records.length;
+    if (numDataPoints <= 0)
+        return null;
+
+    let dataString = '';
+    for (let i = 0; i < numDataPoints; i++) {
+        dataString += `${
+            Math.round(records[i].X * 100) / 100
+            } ${
+            Math.round(records[i].Y * 100) / 100
+            } ${
+            Math.round(records[i].Z * 100) / 100
+            } ${
+            records[i].SIGNAL_STRENGTH
+            }`;
+        if (i < numDataPoints - 1)
+            dataString += '\n';
+    }
+    return new Buffer.from(dataString);
+}
+
+// converts a set of csv records to a buffer of ply data (cartesian point cloud)
+let _convertRecordsToPLYBuffer = function (records, bCompressToBinary) {
+    let numDataPoints = records.length;
+    if (numDataPoints <= 0)
+        return null;
+
+    let header = _generatePLYHeader(numDataPoints, bCompressToBinary);
+
+    if (bCompressToBinary) {
+        let numBytesPerPoint = 13;
+        let numHeaderBytes = header.length;
+        let buffSizeInBytes = numHeaderBytes + (numDataPoints * numBytesPerPoint);
+
+        // prepare the length of the buffer to the correct number of bytes
+        buffer = new Buffer(buffSizeInBytes);
+
+        // write the header to the buffer
+        buffer.write(header);
+
+        // write the points to the buffer
+        let byteOffset = 0;
+        for (let i = 0; i < numDataPoints; i++) {
+            if ((typeof records[i] === 'undefined') || (typeof records[i].X === 'undefined') ||
+                (typeof records[i].Y === 'undefined') || (typeof records[i].Z === 'undefined') ||
+                (typeof records[i].SIGNAL_STRENGTH === 'undefined')) {
+                return null;
+            }
+
+            byteOffset = numHeaderBytes + i * numBytesPerPoint;
+            // write the coordinates as floats in Little-Endian format
+            buffer.writeFloatLE(Math.round(records[i].X * 100) / 100, byteOffset);
+            buffer.writeFloatLE(Math.round(records[i].Y * 100) / 100, byteOffset + 4);
+            buffer.writeFloatLE(Math.round(records[i].Z * 100) / 100, byteOffset + 8);
+            // write the signal strength as a uint8
+            buffer.writeUInt8(records[i].SIGNAL_STRENGTH, byteOffset + 12)
+        }
+    }
+    else {
+        let dataString = header;
+        for (let i = 0; i < numDataPoints; i++) {
+            dataString += `\n${
+                Math.round(records[i].X * 100) / 100
+                } ${
+                Math.round(records[i].Y * 100) / 100
+                } ${
+                Math.round(records[i].Z * 100) / 100
+                } ${
+                records[i].SIGNAL_STRENGTH
+                }`;
+        }
+        buffer = new Buffer.from(dataString);
+    }
+
+    return buffer;
+}
+
+// creates a ply file header
+let _generatePLYHeader = function (numPoints, bCompressToBinary) {
+    let header = "ply\n";
+    header += `format ${bCompressToBinary ? 'binary_little_endian' : 'ascii'} 1.0\n`;
+    header += `element vertex ${numPoints}\n`;
+    header += "property float x\n";
+    header += "property float y\n";
+    header += "property float z\n";
+    header += "property uchar signal_strength\n";
+    header += `end_header${bCompressToBinary ? "\n" : ''}`;
+    return header;
+};

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.17.1",
+    "csv-parse": "^1.2.1",
+    "replace-ext": "^1.0.0",
     "express": "^4.15.2",
     "jade": "^1.11.0"
   }

--- a/public/javascript/pages/file_manager.js
+++ b/public/javascript/pages/file_manager.js
@@ -36,13 +36,16 @@ function populateFilesSelect(files) {
     }
 
     /* loop through the available files programmatically create an option for each */
-    let file, optionName, optionHTML;
+    let file, nameNoExt, optionName, optionHTML;
     for (let i = 0; i < files.length; i++) {
         file = files[i];
+        nameNoExt = file.substring(0, file.lastIndexOf('.csv'));
+        if (nameNoExt.length <= 0)
+            continue;
         //create a new button, and insert it into the dropdown
-        optionName = `option_File_${file}`;
+        optionName = `option_File_${nameNoExt}`;
         optionHTML = `  <option id="${optionName}" value="${file}"> 
-                            ${file}
+                            ${nameNoExt}
                         </option>`
         $("#select_FileName").append(optionHTML);
     }
@@ -83,11 +86,15 @@ function showSuccess(msg) {
 
 
 function downloadFile() {
+    // read desired format
+    //let format = 'ply';
+    let format = $("#form_FileManager input[type='radio']:checked").val();
     // read the filename from the select dropdown
     let filename = $('#select_FileName').find(":selected").val();
+
     // download the file with a dialog by opening a separate window
     if (filename.length > 0) {
-        window.open(`/file_manager/download_file/${filename}`);
+        window.open(`/file_manager/download_file/${format}/${filename}`);
     }
 }
 

--- a/routes/file_manager.js
+++ b/routes/file_manager.js
@@ -8,15 +8,11 @@ const path = require('path');
 const fs = require('fs');
 const express = require('express');
 const bodyParser = require('body-parser');
-const csv_parse = require('csv-parse/lib/sync');
-const replaceExt = require('replace-ext');
+const _STORAGE = require('../js/storage.js');
 
-// backend variables
-const scan_file_dir = path.join(__dirname, "../output_scans/");
-// create directory if it doesn't yet exist
-if (!fs.existsSync(scan_file_dir)) {
-    fs.mkdirSync(scan_file_dir);
-}
+// Backend consts + variables
+const SCAN_FILE_DIR = path.join(__dirname, "../output_scans/");
+const FILE_MANAGER = new _STORAGE.ScanFileManager(SCAN_FILE_DIR);
 
 // Setup express
 var app = express();
@@ -33,7 +29,7 @@ app.use(router);
 router.route('/request_scan_files')
     .get(function (req, res, next) {
         res.send({
-            files: getScanFiles()
+            files: FILE_MANAGER.getScanFiles()
         });
     })
 
@@ -42,11 +38,11 @@ router.route('/delete_file')
     .get(function (req, res, next) {
         let filename = req.query.file;
         console.log(`Deleting...${filename}`);
-        deleteFile(filename);
+        FILE_MANAGER.deleteFile(filename);
         res.send({
             bSuccessfullyDeletedFile: true,
             file: filename,
-            updatedFileList: getScanFiles()
+            updatedFileList: FILE_MANAGER.getScanFiles()
             //errorMsg: ""
         });
     })
@@ -56,208 +52,14 @@ router.route('/download_file/:format/:file(*)')
     .get(function (req, res, next) {
         let filename = req.params.file;
         let format = req.params.format;
-        let filePath = null;
-        switch (format) {
-            case 'csv':
-                filePath = path.join(scan_file_dir, filename);
-                break;
-            case 'ply':
-                filePath = generatePLYFile(filename, false);
-                break;
-            case 'ply_binary':
-                filePath = generatePLYFile(filename, true);
-                break;
-            case 'xyz':
-                filePath = generateXYZFile(filename);
-                break;
-            default:
-                break;
-        }
+        let downloadPath = FILE_MANAGER.getFormattedFile(filename, format);
 
-        if (filePath && fs.existsSync(filePath))
-            res.download(filePath, function (err) {
-                // delete any generated files
+        if (_STORAGE.checkFileExists(downloadPath))
+            res.download(downloadPath, function (err) {
+                // delete any generated files after sending them
                 if (format !== 'csv')
-                    fs.unlinkSync(filePath);
+                    _STORAGE.deleteFile(downloadPath);
             });
     })
-
-// returns a list of available scan files
-function getScanFiles() {
-    // retrieve and chronolgically sort the file names
-    let file_names = fs.readdirSync(scan_file_dir);
-    file_names.sort(compareFileTimestampDescending);
-    return file_names;
-}
-
-// compare function used to sort a list of filenames in descending chronological order 
-// (ie: most recent first)
-function compareFileTimestampDescending(file_a, file_b) {
-    return fs.statSync(path.join(scan_file_dir, file_b)).mtime.getTime() -
-        fs.statSync(path.join(scan_file_dir, file_a)).mtime.getTime();
-}
-
-// deletes a specific scan file
-function deleteFile(filename) {
-    //let file = path.join('./output_scans/', filename);
-    let file = path.join(scan_file_dir, filename);
-    fs.unlinkSync(file);
-}
-
-// generate XYZ file from the specified CSV file
-// return the filepath if successfull, null otherwise
-function generateXYZFile(csvFile) {
-    let csvPath = path.join(scan_file_dir, csvFile);
-    let records = getRecords(csvPath);
-
-    if (typeof records === 'undefined' || typeof records[0] === 'undefined')
-        return null;
-
-    let buffer = convertRecordsToXYZBuffer(records);
-
-    if (!buffer)
-        return null;
-
-    let xyzPath = replaceExt(csvPath, '.xyz');
-    fs.writeFileSync(xyzPath, buffer);
-    return xyzPath;
-}
-
-// generate PLY file from the specified CSV file
-// return the filepath if successfull, null otherwise
-function generatePLYFile(csvFile, bCompressToBinary) {
-    let csvPath = path.join(scan_file_dir, csvFile);
-    let records = getRecords(csvPath);
-
-    if (typeof records === 'undefined' || typeof records[0] === 'undefined')
-        return null;
-
-    let buffer = convertRecordsToPLYBuffer(records, bCompressToBinary);
-
-    if (!buffer)
-        return null;
-
-    let plyPath = replaceExt(csvPath, '.ply');
-    fs.writeFileSync(plyPath, buffer);
-    return plyPath;
-}
-
-function getRecords(csvPath) {
-    let data = null;
-    try {
-        data = fs.readFileSync(csvPath);
-    }
-    catch (err) {
-        console.log(`Failed to read file ${csvPath}. Error: ${err.message}`);
-        return null;
-    }
-
-    // parse the records from the csv
-    let records = null;
-
-    // csv parse options
-    let options = { columns: true, skip_empty_lines: true, trim: true, auto_parse: true };
-    try {
-        records = csv_parse(data, options);
-    }
-    catch (err) {
-        console.log(`Failed to parse CSV file. Error: ${err.message}`);
-        return null;
-    }
-    return records;
-}
-
-// converts a set of csv records to a buffer of xyz data (cartesian point cloud)
-function convertRecordsToXYZBuffer(records) {
-    let numDataPoints = records.length;
-    if (numDataPoints <= 0)
-        return null;
-
-    let dataString = '';
-    for (let i = 0; i < numDataPoints; i++) {
-        dataString += `${
-            Math.round(records[i].X * 100) / 100
-            } ${
-            Math.round(records[i].Y * 100) / 100
-            } ${
-            Math.round(records[i].Z * 100) / 100
-            } ${
-            records[i].SIGNAL_STRENGTH
-            }`;
-        if (i < numDataPoints - 1)
-            dataString += '\n';
-    }
-    return new Buffer.from(dataString);
-}
-
-// converts a set of csv records to a buffer of ply data (cartesian point cloud)
-function convertRecordsToPLYBuffer(records, bCompressToBinary) {
-    let numDataPoints = records.length;
-    if (numDataPoints <= 0)
-        return null;
-
-    let header = generatePLYHeader(numDataPoints, bCompressToBinary);
-
-    if (bCompressToBinary) {
-        let numBytesPerPoint = 13;
-        let numHeaderBytes = header.length;
-        let buffSizeInBytes = numHeaderBytes + (numDataPoints * numBytesPerPoint);
-
-        // prepare the length of the buffer to the correct number of bytes
-        buffer = new Buffer(buffSizeInBytes);
-
-        // write the header to the buffer
-        buffer.write(header);
-
-        // write the points to the buffer
-        let byteOffset = 0;
-        for (let i = 0; i < numDataPoints; i++) {
-            if ((typeof records[i] === 'undefined') || (typeof records[i].X === 'undefined') ||
-                (typeof records[i].Y === 'undefined') || (typeof records[i].Z === 'undefined') ||
-                (typeof records[i].SIGNAL_STRENGTH === 'undefined')) {
-                return null;
-            }
-
-            byteOffset = numHeaderBytes + i * numBytesPerPoint;
-            // write the coordinates as floats in Little-Endian format
-            buffer.writeFloatLE(Math.round(records[i].X * 100) / 100, byteOffset);
-            buffer.writeFloatLE(Math.round(records[i].Y * 100) / 100, byteOffset + 4);
-            buffer.writeFloatLE(Math.round(records[i].Z * 100) / 100, byteOffset + 8);
-            // write the signal strength as a uint8
-            buffer.writeUInt8(records[i].SIGNAL_STRENGTH, byteOffset + 12)
-        }
-    }
-    else {
-        let dataString = header;
-        for (let i = 0; i < numDataPoints; i++) {
-            dataString += `\n${
-                Math.round(records[i].X * 100) / 100
-                } ${
-                Math.round(records[i].Y * 100) / 100
-                } ${
-                Math.round(records[i].Z * 100) / 100
-                } ${
-                records[i].SIGNAL_STRENGTH
-                }`;
-        }
-        buffer = new Buffer.from(dataString);
-    }
-
-    return buffer;
-}
-
-// creates a ply file header
-function generatePLYHeader(numPoints, bCompressToBinary) {
-    let header = "ply\n";
-    header += `format ${bCompressToBinary ? 'binary_little_endian' : 'ascii'} 1.0\n`;
-    header += `element vertex ${numPoints}\n`;
-    header += "property float x\n";
-    header += "property float y\n";
-    header += "property float z\n";
-    header += "property uchar signal_strength\n";
-    header += `end_header${bCompressToBinary ? "\n" : ''}`;
-    return header;
-};
-
 
 module.exports = app;

--- a/routes/file_manager.js
+++ b/routes/file_manager.js
@@ -8,6 +8,8 @@ const path = require('path');
 const fs = require('fs');
 const express = require('express');
 const bodyParser = require('body-parser');
+const csv_parse = require('csv-parse/lib/sync');
+const replaceExt = require('replace-ext');
 
 // backend variables
 const scan_file_dir = path.join(__dirname, "../output_scans/");
@@ -50,11 +52,34 @@ router.route('/delete_file')
     })
 
 // handle request to download a specific file
-router.route('/download_file/:file(*)')
+router.route('/download_file/:format/:file(*)')
     .get(function (req, res, next) {
         let filename = req.params.file;
-        if (checkFile(filename))
-            res.download(path.join(scan_file_dir, filename));
+        let format = req.params.format;
+        let filePath = null;
+        switch (format) {
+            case 'csv':
+                filePath = path.join(scan_file_dir, filename);
+                break;
+            case 'ply':
+                filePath = generatePLYFile(filename, false);
+                break;
+            case 'ply_binary':
+                filePath = generatePLYFile(filename, true);
+                break;
+            case 'xyz':
+                filePath = generateXYZFile(filename);
+                break;
+            default:
+                break;
+        }
+
+        if (filePath && fs.existsSync(filePath))
+            res.download(filePath, function (err) {
+                // delete any generated files
+                if (format !== 'csv')
+                    fs.unlinkSync(filePath);
+            });
     })
 
 // returns a list of available scan files
@@ -79,10 +104,160 @@ function deleteFile(filename) {
     fs.unlinkSync(file);
 }
 
-// returns true if file exists
-function checkFile(filename) {
-    let file = path.join(scan_file_dir, filename);
-    return fs.existsSync(file);
+// generate XYZ file from the specified CSV file
+// return the filepath if successfull, null otherwise
+function generateXYZFile(csvFile) {
+    let csvPath = path.join(scan_file_dir, csvFile);
+    let records = getRecords(csvPath);
+
+    if (typeof records === 'undefined' || typeof records[0] === 'undefined')
+        return null;
+
+    let buffer = convertRecordsToXYZBuffer(records);
+
+    if (!buffer)
+        return null;
+
+    let xyzPath = replaceExt(csvPath, '.xyz');
+    fs.writeFileSync(xyzPath, buffer);
+    return xyzPath;
 }
+
+// generate PLY file from the specified CSV file
+// return the filepath if successfull, null otherwise
+function generatePLYFile(csvFile, bCompressToBinary) {
+    let csvPath = path.join(scan_file_dir, csvFile);
+    let records = getRecords(csvPath);
+
+    if (typeof records === 'undefined' || typeof records[0] === 'undefined')
+        return null;
+
+    let buffer = convertRecordsToPLYBuffer(records, bCompressToBinary);
+
+    if (!buffer)
+        return null;
+
+    let plyPath = replaceExt(csvPath, '.ply');
+    fs.writeFileSync(plyPath, buffer);
+    return plyPath;
+}
+
+function getRecords(csvPath) {
+    let data = null;
+    try {
+        data = fs.readFileSync(csvPath);
+    }
+    catch (err) {
+        console.log(`Failed to read file ${csvPath}. Error: ${err.message}`);
+        return null;
+    }
+
+    // parse the records from the csv
+    let records = null;
+
+    // csv parse options
+    let options = { columns: true, skip_empty_lines: true, trim: true, auto_parse: true };
+    try {
+        records = csv_parse(data, options);
+    }
+    catch (err) {
+        console.log(`Failed to parse CSV file. Error: ${err.message}`);
+        return null;
+    }
+    return records;
+}
+
+// converts a set of csv records to a buffer of xyz data (cartesian point cloud)
+function convertRecordsToXYZBuffer(records) {
+    let numDataPoints = records.length;
+    if (numDataPoints <= 0)
+        return null;
+
+    let dataString = '';
+    for (let i = 0; i < numDataPoints; i++) {
+        dataString += `${
+            Math.round(records[i].X * 100) / 100
+            } ${
+            Math.round(records[i].Y * 100) / 100
+            } ${
+            Math.round(records[i].Z * 100) / 100
+            } ${
+            records[i].SIGNAL_STRENGTH
+            }`;
+        if (i < numDataPoints - 1)
+            dataString += '\n';
+    }
+    return new Buffer.from(dataString);
+}
+
+// converts a set of csv records to a buffer of ply data (cartesian point cloud)
+function convertRecordsToPLYBuffer(records, bCompressToBinary) {
+    let numDataPoints = records.length;
+    if (numDataPoints <= 0)
+        return null;
+
+    let header = generatePLYHeader(numDataPoints, bCompressToBinary);
+
+    if (bCompressToBinary) {
+        let numBytesPerPoint = 13;
+        let numHeaderBytes = header.length;
+        let buffSizeInBytes = numHeaderBytes + (numDataPoints * numBytesPerPoint);
+
+        // prepare the length of the buffer to the correct number of bytes
+        buffer = new Buffer(buffSizeInBytes);
+
+        // write the header to the buffer
+        buffer.write(header);
+
+        // write the points to the buffer
+        let byteOffset = 0;
+        for (let i = 0; i < numDataPoints; i++) {
+            if ((typeof records[i] === 'undefined') || (typeof records[i].X === 'undefined') ||
+                (typeof records[i].Y === 'undefined') || (typeof records[i].Z === 'undefined') ||
+                (typeof records[i].SIGNAL_STRENGTH === 'undefined')) {
+                return null;
+            }
+
+            byteOffset = numHeaderBytes + i * numBytesPerPoint;
+            // write the coordinates as floats in Little-Endian format
+            buffer.writeFloatLE(Math.round(records[i].X * 100) / 100, byteOffset);
+            buffer.writeFloatLE(Math.round(records[i].Y * 100) / 100, byteOffset + 4);
+            buffer.writeFloatLE(Math.round(records[i].Z * 100) / 100, byteOffset + 8);
+            // write the signal strength as a uint8
+            buffer.writeUInt8(records[i].SIGNAL_STRENGTH, byteOffset + 12)
+        }
+    }
+    else {
+        let dataString = header;
+        for (let i = 0; i < numDataPoints; i++) {
+            dataString += `\n${
+                Math.round(records[i].X * 100) / 100
+                } ${
+                Math.round(records[i].Y * 100) / 100
+                } ${
+                Math.round(records[i].Z * 100) / 100
+                } ${
+                records[i].SIGNAL_STRENGTH
+                }`;
+        }
+        buffer = new Buffer.from(dataString);
+    }
+
+    return buffer;
+}
+
+// creates a ply file header
+function generatePLYHeader(numPoints, bCompressToBinary) {
+    let header = "ply\n";
+    header += `format ${bCompressToBinary ? 'binary_little_endian' : 'ascii'} 1.0\n`;
+    header += `element vertex ${numPoints}\n`;
+    header += "property float x\n";
+    header += "property float y\n";
+    header += "property float z\n";
+    header += "property uchar signal_strength\n";
+    header += `end_header${bCompressToBinary ? "\n" : ''}`;
+    return header;
+};
+
 
 module.exports = app;

--- a/views/file_manager.jade
+++ b/views/file_manager.jade
@@ -10,15 +10,32 @@ block content
         small.bg-danger Press the red button to delete it from the rPi.
     hr
 
-    label Select File
-    form.form-inline
+    form.form-vertical(id="form_FileManager")
+        label.control-label Downloaded File Format:
         div.form-group
+            label.radio-inline
+                input(type='radio', name='format_radio', value='csv', checked)
+                | CSV
+            label.radio-inline
+                input(type='radio', name='format_radio', value='ply')
+                |  PLY
+            label.radio-inline
+                input(type='radio', name='format_radio', value='ply_binary')
+                |  PLY (binary)
+            label.radio-inline
+                input(type='radio', name='format_radio', value='xyz')
+                |  XYZ
+        div.form-group
+            label.control-label Select File:
             select.form-control.input-lg(id="select_FileName")
         div.form-group
-            button.btn-lg.btn.btn-primary(id="btn_DownloadFile", type="button" name="submit" value="download")
-                span.glyphicon.glyphicon-download
-            button.btn-lg.btn.btn-danger(id="btn_DeleteFile", type="button" name="submit" value="delete")
-                span.glyphicon.glyphicon-trash
+            div.btn-group.btn-group-justified
+                div.btn-group
+                    button.btn-lg.btn.btn-primary(id="btn_DownloadFile", type="button" name="submit" value="download")
+                        span.glyphicon.glyphicon-download
+                div.btn-group
+                    button.btn-lg.btn.btn-danger(id="btn_DeleteFile", type="button" name="submit" value="delete")
+                        span.glyphicon.glyphicon-trash
     br
     div.alert.alert-success(id="alert_Success", role="alert", style="display: none;")
     div.alert.alert-warning(id="alert_Warning", role="alert", style="display: none;")


### PR DESCRIPTION
#### Scope of changes
- Adds download options for PLY, PLY (binary) and XYZ file formats.
- Only stores .csv files
- Webapp generates the alternate file formats when download is requested, and deletes alternate files after serving them.
- Abstracts storage logic to dedicated node module called `storage`, the src for which resides in a new `js/` directory
- `storage` module can be included in multiple routes like any other node package
- `storage` module contains `ScanFileManager` class for managing common tasks related to scan files, without requiring high level calling logic concern itself with file paths.

#### Known Limitations
- XYZ format includes the signal strength. Most programs that import .xyz can deal with additional scalar columns
- PLY formats use float values despite coordinates being rounded integers. This is to keep format consistent with exports from the sweep-visualizer and is likely to change soon.